### PR TITLE
STAC-0: Bring topic describe in line with api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         if: steps.cache-image.outputs.cache-hit != 'true'
         env:
           DOCKER_TLS_CERTDIR: ""
-          CI_BASE_IMAGE_PUSH: quay.io/stackstate/sts-ci-images:stackstate-cli2-${{ env.NIX_CHECKSUM }}
+          CI_BASE_IMAGE_PUSH: quay.io/stackstate/stackstate-cli:stackstate-cli2-${{ env.NIX_CHECKSUM }}
         run: |
           echo "${{ secrets.QUAY_PASSWORD }}" | docker login --username=${{ secrets.QUAY_USER }} --password-stdin quay.io
           docker load < result
@@ -72,7 +72,7 @@ jobs:
 
     outputs:
       nixChecksum: ${{ env.NIX_CHECKSUM }}
-      ciImageName: quay.io/stackstate/sts-ci-images:stackstate-cli2-${{ env.NIX_CHECKSUM }}
+      ciImageName: quay.io/stackstate/stackstate-cli:stackstate-cli2-${{ env.NIX_CHECKSUM }}
       sourceAffected: ${{ steps.source-affected.outputs.src }}
 
   lint:

--- a/cmd/topic/topic_describe.go
+++ b/cmd/topic/topic_describe.go
@@ -25,7 +25,7 @@ const (
 	PartitionUsage = "The Kafka partition to query"
 	FileUsage      = "The JSON output file to save the messages to"
 
-	DefaultLimit   = int32(10)
+	DefaultLimit = int32(10)
 )
 
 type DescribeArgs struct {
@@ -61,15 +61,15 @@ func argValueError(name string, value int32) common.CLIError {
 }
 
 func fetchMessages(request stackstate_api.ApiDescribeRequest, args *DescribeArgs) ([]stackstate_api.Message, common.CLIError) {
-  if args.Offset != -1 {
-    request = request.Offset(args.Offset)
-  }
+	if args.Offset != -1 {
+		request = request.Offset(args.Offset)
+	}
 
-  result, resp, err := request.Limit(args.Limit).Execute()
+	result, resp, err := request.Limit(args.Limit).Execute()
 
-  if err != nil {
-    return nil, common.NewResponseError(err, resp)
-  }
+	if err != nil {
+		return nil, common.NewResponseError(err, resp)
+	}
 
 	return result.Messages, nil
 }

--- a/cmd/topic/topic_describe.go
+++ b/cmd/topic/topic_describe.go
@@ -3,7 +3,6 @@ package topic
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 
 	"github.com/spf13/cobra"
 	"github.com/stackvista/stackstate-cli/generated/stackstate_api"
@@ -16,27 +15,23 @@ import (
 const (
 	Name      = "name"
 	Offset    = "offset"
-	Number    = "nr"
+	Limit     = "limit"
 	PageSize  = "pagesize"
 	Partition = "partition"
 
 	NameUsage      = "Topic name"
 	OffsetUsage    = "The starting offset"
-	NumberUsage    = "The number of messages to show"
-	PageSizeUsage  = "The pagination size"
+	LimitUsage     = "The limit of messages to show"
 	PartitionUsage = "The Kafka partition to query"
 	FileUsage      = "The JSON output file to save the messages to"
 
-	DefaultOffset   = int32(0)
-	DefaultNumber   = int32(10)
-	DefaultPageSize = int32(10000)
+	DefaultLimit   = int32(10)
 )
 
 type DescribeArgs struct {
 	Name      string
 	Offset    int32
-	Number    int32
-	PageSize  int32
+	Limit     int32
 	Partition int32
 	File      string
 }
@@ -53,9 +48,8 @@ func DescribeCommand(deps *di.Deps) *cobra.Command {
 	cmd.Flags().StringVar(&args.Name, Name, "", NameUsage)
 	cmd.MarkFlagRequired(Name) //nolint:errcheck
 
-	cmd.Flags().Int32Var(&args.Offset, Offset, DefaultOffset, OffsetUsage)
-	cmd.Flags().Int32Var(&args.Number, Number, DefaultNumber, NumberUsage)
-	cmd.Flags().Int32Var(&args.PageSize, PageSize, DefaultPageSize, PageSizeUsage)
+	cmd.Flags().Int32Var(&args.Offset, Offset, -1, OffsetUsage)
+	cmd.Flags().Int32Var(&args.Limit, Limit, DefaultLimit, LimitUsage)
 	cmd.Flags().Int32Var(&args.Partition, Partition, -1, PartitionUsage)
 	common.AddFileFlagVar(cmd, &args.File, FileUsage)
 
@@ -67,41 +61,17 @@ func argValueError(name string, value int32) common.CLIError {
 }
 
 func fetchMessages(request stackstate_api.ApiDescribeRequest, args *DescribeArgs) ([]stackstate_api.Message, common.CLIError) {
-	// NOTE Fetch up to args.Number messages from the topic, at most args.PageSize at a time starting at args.Offset.
-	remaining := args.Number
-	offset := args.Offset
-	messages := make([]stackstate_api.Message, 0)
+  if args.Offset != -1 {
+    request = request.Offset(args.Offset)
+  }
 
-	for remaining > 0 {
-		pageSize := args.PageSize
+  result, resp, err := request.Limit(args.Limit).Execute()
 
-		if remaining < args.PageSize {
-			pageSize = remaining
-		}
+  if err != nil {
+    return nil, common.NewResponseError(err, resp)
+  }
 
-		result, resp, err := request.Offset(offset).Limit(pageSize).Execute()
-
-		if err != nil {
-			return nil, common.NewResponseError(err, resp)
-		}
-
-		messages = append(messages, result.Messages...)
-
-		if int32(len(result.Messages)) < pageSize {
-			// Exhausted the topic.
-			remaining = 0
-		} else {
-			// Prepare to fetch the next page.
-			offset += pageSize
-			remaining -= pageSize
-		}
-	}
-
-	sort.SliceStable(messages, func(i, j int) bool {
-		return messages[i].Offset < messages[j].Offset
-	})
-
-	return messages, nil
+	return result.Messages, nil
 }
 
 func RunDescribeCommand(args *DescribeArgs) di.CmdWithApiFn {
@@ -111,14 +81,11 @@ func RunDescribeCommand(args *DescribeArgs) di.CmdWithApiFn {
 		api *stackstate_api.APIClient,
 		serverInfo *stackstate_api.ServerInfo,
 	) common.CLIError {
-		if args.Offset < 0 {
+		if args.Offset < -1 {
 			return argValueError(Offset, args.Offset)
 		}
-		if args.Number < 1 {
-			return argValueError(Number, args.Number)
-		}
-		if args.PageSize < 1 {
-			return argValueError(PageSize, args.PageSize)
+		if args.Limit < 1 {
+			return argValueError(Limit, args.Limit)
 		}
 
 		request := api.TopicApi.Describe(cli.Context, args.Name)

--- a/cmd/topic/topic_describe_test.go
+++ b/cmd/topic/topic_describe_test.go
@@ -231,4 +231,3 @@ func TestTopicDescribeMoreThanAvailable(t *testing.T) {
 
 	assert.Equal(t, expectedJson, *cli.MockPrinter.PrintJsonCalls)
 }
-

--- a/cmd/topic/topic_describe_test.go
+++ b/cmd/topic/topic_describe_test.go
@@ -38,9 +38,9 @@ var (
 	}
 	AllMessagesListSorted = []stackstate_api.Message{
 		*Message1,
-		*Message4,
 		*Message2,
 		*Message3,
+		*Message4,
 		*Message5,
 	}
 	AllTopicMessages = stackstate_api.NewMessages(AllMessagesList)
@@ -109,9 +109,9 @@ func TestTopicDescribeTableSorting(t *testing.T) {
 			Header: []string{"Key", "Partition", "Offset", "Message"},
 			Data: [][]interface{}{
 				{Message1.Key, Message1.Partition, Message1.Offset, MessageContentsJson},
-				{Message4.Key, Message4.Partition, Message4.Offset, MessageContentsJson},
 				{Message2.Key, Message2.Partition, Message2.Offset, MessageContentsJson},
 				{Message3.Key, Message3.Partition, Message3.Offset, MessageContentsJson},
+				{Message4.Key, Message4.Partition, Message4.Offset, MessageContentsJson},
 				{Message5.Key, Message5.Partition, Message5.Offset, MessageContentsJson},
 			},
 			MissingTableDataMsg: printer.NotFoundMsg{Types: "messages"},
@@ -162,7 +162,7 @@ func TestTopicDescribeFileIO(t *testing.T) {
 	assert.Equal(t, strings.Trim(string(expectedContents), "\n"), string(written))
 }
 
-func TestTopicDescribePaginationDefaults(t *testing.T) {
+func TestTopicDescribeDefaults(t *testing.T) {
 	cli := di.NewMockDeps(t)
 	cmd := DescribeCommand(&cli.Deps)
 
@@ -173,8 +173,8 @@ func TestTopicDescribePaginationDefaults(t *testing.T) {
 	calls := *cli.MockClient.ApiMocks.TopicApi.DescribeCalls
 	assert.Len(t, calls, 1)
 	assert.Equal(t, "test", calls[0].Ptopic)
-	assert.Equal(t, DefaultNumber, *calls[0].Plimit)
-	assert.Equal(t, DefaultOffset, *calls[0].Poffset)
+	assert.Equal(t, DefaultLimit, *calls[0].Plimit)
+	assert.Nil(t, calls[0].Poffset)
 	assert.Nil(t, calls[0].Ppartition)
 
 	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "--name", "test", "--partition", "23")
@@ -192,10 +192,8 @@ type InvalidArgs struct {
 func TestTopicDescribePaginationLimits(t *testing.T) {
 	tests := []InvalidArgs{
 		{Name: Offset, Value: -23},
-		{Name: Number, Value: -5},
-		{Name: Number, Value: 0},
-		{Name: PageSize, Value: -13},
-		{Name: PageSize, Value: 0},
+		{Name: Limit, Value: -5},
+		{Name: Limit, Value: 0},
 	}
 
 	for _, test := range tests {
@@ -211,18 +209,18 @@ func TestTopicDescribePaginationLimits(t *testing.T) {
 	}
 }
 
-func TestTopicDescribePaginationMoreThanAvailable(t *testing.T) {
+func TestTopicDescribeMoreThanAvailable(t *testing.T) {
 	cli := di.NewMockDeps(t)
 	cmd := DescribeCommand(&cli.Deps)
 
 	cli.MockClient.ApiMocks.TopicApi.DescribeResponse.Result = *AllTopicMessages
 
-	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "--name", "test", "--nr", "10", "-o", "json")
+	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "--name", "test", "--limit", "10", "-o", "json")
 
 	calls := *cli.MockClient.ApiMocks.TopicApi.DescribeCalls
 	assert.Len(t, calls, 1)
 	assert.Equal(t, "test", calls[0].Ptopic)
-	assert.Equal(t, int32(0), *calls[0].Poffset)
+	assert.Nil(t, calls[0].Poffset)
 	assert.Equal(t, int32(10), *calls[0].Plimit)
 
 	expectedJson := []map[string]interface{}{
@@ -234,48 +232,3 @@ func TestTopicDescribePaginationMoreThanAvailable(t *testing.T) {
 	assert.Equal(t, expectedJson, *cli.MockPrinter.PrintJsonCalls)
 }
 
-func TestTopicDescribePaginationPagedRetrieval(t *testing.T) {
-	cli := di.NewMockDeps(t)
-	cmd := DescribeCommand(&cli.Deps)
-
-	cli.MockClient.ApiMocks.TopicApi.DescribeResponse.Result = *Part0TopicMessages
-
-	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "--name", "test", "--nr", "10", "--pagesize", "3", "-o", "json")
-
-	calls := *cli.MockClient.ApiMocks.TopicApi.DescribeCalls
-	assert.Len(t, calls, 4)
-	assert.Equal(t, int32(0), *calls[0].Poffset)
-	assert.Equal(t, int32(3), *calls[0].Plimit)
-
-	assert.Equal(t, int32(3), *calls[1].Poffset)
-	assert.Equal(t, int32(3), *calls[1].Plimit)
-
-	assert.Equal(t, int32(6), *calls[2].Poffset)
-	assert.Equal(t, int32(3), *calls[2].Plimit)
-
-	assert.Equal(t, int32(9), *calls[3].Poffset)
-	assert.Equal(t, int32(1), *calls[3].Plimit)
-
-	expectedJson := []map[string]interface{}{
-		{
-			// NOTE The mock API returns more than limit on the last call.
-			// NOTE The messages are then sorted by offset.
-			"messages": []stackstate_api.Message{
-				*Message1,
-				*Message1,
-				*Message1,
-				*Message1,
-				*Message2,
-				*Message2,
-				*Message2,
-				*Message2,
-				*Message3,
-				*Message3,
-				*Message3,
-				*Message3,
-			},
-		},
-	}
-
-	assert.Equal(t, expectedJson, *cli.MockPrinter.PrintJsonCalls)
-}


### PR DESCRIPTION
The cli topic api tries to 'paginate' the data coming form kafka, which is now very broken, because we do not make partition offset and the like first class in the stackstate api (making pagination impossible).

This mr drops the pagination and makes sure that when no offset is defined, we take the latest messages (which is what the user typically wants, instead of offset 0)