### PR TITLE
STAC-22970: Environment variables for ca-cert-path and ca-cert-base64-data

### DIFF
--- a/internal/config/viper.go
+++ b/internal/config/viper.go
@@ -22,7 +22,7 @@ func Bind(cmd *cobra.Command, vp *viper.Viper) *ViperConfig {
 	vp.BindEnv("context", "STS_CLI_CONTEXT")
 	vp.BindEnv("skip-ssl", "STS_SKIP_SSL")
 	vp.BindEnv("ca-cert-path", "STS_CA_CERT_PATH")
-	vp.BindEnv("ca-cert-base64-data", "STS_CA_CERT_BASE64_PATH")
+	vp.BindEnv("ca-cert-base64-data", "STS_CA_CERT_BASE64_DATA")
 
 	// bind flags
 	vp.BindPFlag("url", cmd.Flags().Lookup("url"))

--- a/internal/config/viper.go
+++ b/internal/config/viper.go
@@ -21,6 +21,8 @@ func Bind(cmd *cobra.Command, vp *viper.Viper) *ViperConfig {
 	vp.BindEnv("api-path", "STS_CLI_API_PATH")
 	vp.BindEnv("context", "STS_CLI_CONTEXT")
 	vp.BindEnv("skip-ssl", "STS_SKIP_SSL")
+	vp.BindEnv("ca-cert-path", "STS_CA_CERT_PATH")
+	vp.BindEnv("ca-cert-base64-data", "STS_CA_CERT_BASE64_PATH")
 
 	// bind flags
 	vp.BindPFlag("url", cmd.Flags().Lookup("url"))


### PR DESCRIPTION
Just for the documentation consistency, all args have their ENV counterparts - https://documentation.suse.com/cloudnative/suse-observability/next/en/setup/cli/cli-sts.html#_configuration_options