### PR TITLE
STAC-24007: Remove repetitions from Usage descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ sts context save --name ci-pipeline --url https://suse-observability.example.com
 
 ### Quality Checklist
 For every cobra.Command:
-- [ ] `Use` contains only the command name and positional arguments (no flags)
+- [ ] `Use` contains only the command name
 - [ ] `Short` starts with verb, no period, adds context beyond command name
 - [ ] `Long` adds value beyond `Short`, ends with period, explains domain concepts
 - [ ] `Example` has 2-3 realistic, copy-pasteable examples with lowercase comments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,12 +106,10 @@ From CMD_DEVELOPMENT.md - critical rules for consistency:
 Per ADR 001: CLI `--help` output is the **authoritative source** for command documentation. External docs provide overviews only. This means help text must be self-sufficient, consistent, and include practical examples.
 
 ### Use Field Rules
-- **Noun-level commands**: `Use: "context"` (command appended automatically)
-- **Noun-verb commands**: `Use: "save --url URL {--api-token TOKEN | --service-token TOKEN}"`
-- **Required flags**: Show without brackets: `--url URL`
-- **Mutually exclusive required**: Group in `{}` with `|`: `{--api-token TOKEN | --service-token TOKEN}`
-- **Mutually exclusive optional**: Group in `[]` with `|`: `[--format JSON | --format YAML]`
-- **Flag values**: Use UPPER-CASE placeholders: `URL`, `TOKEN`, `FILE`
+- **IMPORTANT**: Do NOT include flags in the `Use` field. Required flags and mutually exclusive flag groups are **auto-generated** by `AddRequiredFlagsToUseString()` in `main.go` based on flag annotations set by `MarkMutexFlags()`. Including flags manually causes duplication in the help output.
+- **Noun-level commands**: `Use: "context"` (command name only)
+- **Noun-verb commands**: `Use: "delete"` (verb name only, no flags)
+- **Positional arguments only**: If the command takes positional arguments, include them: `Use: "describe [NAME]"`
 
 ### Short Field Rules
 - Start with **imperative verb** (Save, List, Delete, Show, Set, Validate)
@@ -162,7 +160,7 @@ sts context save --name ci-pipeline --url https://suse-observability.example.com
 
 ### Quality Checklist
 For every cobra.Command:
-- [ ] `Use` shows required flags and mutex groups correctly
+- [ ] `Use` contains only the command name and positional arguments (no flags)
 - [ ] `Short` starts with verb, no period, adds context beyond command name
 - [ ] `Long` adds value beyond `Short`, ends with period, explains domain concepts
 - [ ] `Example` has 2-3 realistic, copy-pasteable examples with lowercase comments

--- a/cmd/context/context_delete.go
+++ b/cmd/context/context_delete.go
@@ -16,7 +16,7 @@ type DeleteArgs struct {
 func DeleteCommand(cli *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete --name NAME",
+		Use:   "delete",
 		Short: "Delete a saved context from the CLI configuration",
 		Long:  "Delete a connection context from the CLI configuration file. The currently active context cannot be deleted; switch to a different context first.",
 		Example: `# delete an unused context

--- a/cmd/context/context_save.go
+++ b/cmd/context/context_save.go
@@ -30,7 +30,7 @@ type SaveArgs struct {
 func SaveCommand(cli *di.Deps) *cobra.Command {
 	args := &SaveArgs{}
 	cmd := &cobra.Command{
-		Use:   "save --url URL {--api-token TOKEN | --service-token TOKEN}",
+		Use:   "save",
 		Short: "Save a connection context to the CLI configuration",
 		Long:  `Save a connection context to the CLI configuration file. The context stores the server URL and authentication credentials. After saving, this context becomes the current active context.`,
 		Example: `# save a context with an API token

--- a/cmd/context/context_set.go
+++ b/cmd/context/context_set.go
@@ -16,7 +16,7 @@ type SetArgs struct {
 func SetCommand(cli *di.Deps) *cobra.Command {
 	args := &SetArgs{}
 	cmd := &cobra.Command{
-		Use:   "set --name NAME",
+		Use:   "set",
 		Short: "Set the active context to use for CLI commands",
 		Long:  "Set the active connection context. All subsequent CLI commands will use this context's server URL and credentials.",
 		Example: `# switch to the production context

--- a/cmd/context/context_validate.go
+++ b/cmd/context/context_validate.go
@@ -14,7 +14,7 @@ type ValidateArgs struct {
 func ValidateCommand(cli *di.Deps) *cobra.Command {
 	args := &ValidateArgs{}
 	cmd := &cobra.Command{
-		Use:   "validate [--name NAME]",
+		Use:   "validate",
 		Short: "Validate that a context can connect to the server",
 		Long:  "Validate a connection context by attempting to connect to the SUSE Observability server. Validates the current context if no name is specified.",
 		Example: `# validate the current context

--- a/cmd/dashboard/dashboard_apply.go
+++ b/cmd/dashboard/dashboard_apply.go
@@ -21,7 +21,7 @@ type ApplyArgs struct {
 func DashboardApplyCommand(cli *di.Deps) *cobra.Command {
 	args := &ApplyArgs{}
 	cmd := &cobra.Command{
-		Use:   "apply --file FILE",
+		Use:   "apply",
 		Short: "Create or update a dashboard from a YAML file",
 		Long:  "Create or update a dashboard from a YAML file. If the YAML contains an 'id' field, the existing dashboard is updated; otherwise a new dashboard is created.",
 		Example: `# create a new dashboard from file

--- a/cmd/dashboard/dashboard_clone.go
+++ b/cmd/dashboard/dashboard_clone.go
@@ -29,7 +29,7 @@ func DashboardCloneCommand(cli *di.Deps) *cobra.Command {
 sts dashboard clone --id 123456789 --name My Dashboard Copy
 
 # clone a dashboard as private
-sts dashboard clone --identifier urn:stackpack:my-dashboard --name Private Copy --scope privateDashboard`,
+sts dashboard clone --identifier urn:stackpack:my-dashboard --name "Private Copy" --scope privateDashboard`,
 		RunE: cli.CmdRunEWithApi(RunDashboardCloneCommand(args)),
 	}
 

--- a/cmd/dashboard/dashboard_clone.go
+++ b/cmd/dashboard/dashboard_clone.go
@@ -22,7 +22,7 @@ type CloneArgs struct {
 func DashboardCloneCommand(cli *di.Deps) *cobra.Command {
 	args := &CloneArgs{}
 	cmd := &cobra.Command{
-		Use:   "clone {--id ID | --identifier URN} --name NAME",
+		Use:   "clone",
 		Short: "Clone an existing dashboard to create a new copy",
 		Long:  "Clone an existing dashboard to create a new copy with a different name. Optionally set a new description and scope for the cloned dashboard.",
 		Example: `# clone a dashboard by ID

--- a/cmd/dashboard/dashboard_delete.go
+++ b/cmd/dashboard/dashboard_delete.go
@@ -19,7 +19,7 @@ type DeleteArgs struct {
 func DashboardDeleteCommand(cli *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete {--id ID | --identifier URN}",
+		Use:   "delete",
 		Short: "Delete a dashboard permanently",
 		Long:  "Delete a dashboard by its ID or identifier. Only user-owned dashboards can be deleted.",
 		Example: `# delete a dashboard by ID

--- a/cmd/dashboard/dashboard_describe.go
+++ b/cmd/dashboard/dashboard_describe.go
@@ -21,7 +21,7 @@ type DescribeArgs struct {
 func DashboardDescribeCommand(cli *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe {--id ID | --identifier URN}",
+		Use:   "describe",
 		Short: "Export a dashboard definition in YAML format",
 		Long:  "Export the full dashboard definition in YAML format. Output can be printed to stdout or saved to a file for backup or migration purposes.",
 		Example: `# describe a dashboard by ID

--- a/cmd/dashboard/dashboard_edit.go
+++ b/cmd/dashboard/dashboard_edit.go
@@ -21,7 +21,7 @@ type EditArgs struct {
 func DashboardEditCommand(cli *di.Deps) *cobra.Command {
 	args := &EditArgs{}
 	cmd := &cobra.Command{
-		Use:   "edit {--id ID | --identifier URN}",
+		Use:   "edit",
 		Short: "Edit a dashboard interactively in your default editor",
 		Long:  "Edit a dashboard interactively. Opens the dashboard YAML in the editor defined by your EDITOR environment variable. Changes are applied when you save and close the editor.",
 		Example: `# edit a dashboard by ID

--- a/cmd/health/health_clear_error.go
+++ b/cmd/health/health_clear_error.go
@@ -16,7 +16,7 @@ type ClearErrorArgs struct {
 func HealthClearErrorCommand(cli *di.Deps) *cobra.Command {
 	args := &ClearErrorArgs{}
 	cmd := &cobra.Command{
-		Use:   "clear-error --urn URN",
+		Use:   "clear-error",
 		Short: "Clear errors from a health synchronization stream",
 		Long: `Clear errors from a health synchronization stream, allowing it to resume normal operation. Use this after resolving the underlying cause of synchronization errors.
 

--- a/cmd/health/health_delete.go
+++ b/cmd/health/health_delete.go
@@ -16,7 +16,7 @@ type DeleteArgs struct {
 func HealthDeleteCommand(cli *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete --urn URN",
+		Use:   "delete",
 		Short: "Delete a health synchronization stream",
 		Long:  "Delete a health synchronization stream and all its sub-streams. This removes all check states associated with the stream.",
 		Example: `# delete a health stream

--- a/cmd/health/health_list.go
+++ b/cmd/health/health_list.go
@@ -15,7 +15,7 @@ type ListArgs struct {
 func HealthListCommand(cli *di.Deps) *cobra.Command {
 	args := &ListArgs{}
 	cmd := &cobra.Command{
-		Use:   "list [--urn URN]",
+		Use:   "list",
 		Short: "List health synchronization streams or sub-streams",
 		Long:  "List all health synchronization streams. If a stream URN is provided, lists the sub-streams within that stream instead.",
 		Example: `# list all health streams

--- a/cmd/health/health_status.go
+++ b/cmd/health/health_status.go
@@ -20,7 +20,7 @@ type StatusArgs struct {
 func HealthStatusCommand(cli *di.Deps) *cobra.Command {
 	args := &StatusArgs{}
 	cmd := &cobra.Command{
-		Use:   "status --urn URN",
+		Use:   "status",
 		Short: "Show detailed status of a health synchronization stream",
 		Long:  `Show detailed status of a health synchronization stream including metrics, errors, and consistency state. Use --sub-stream to check a specific sub-stream, or --topology to see topology element matches.`,
 		Example: `# show stream status

--- a/cmd/license/license_update.go
+++ b/cmd/license/license_update.go
@@ -14,7 +14,7 @@ type UpdateArgs struct {
 func UpdateCommand(deps *di.Deps) *cobra.Command {
 	args := &UpdateArgs{}
 	cmd := &cobra.Command{
-		Use:   "update --key KEY",
+		Use:   "update",
 		Short: "Update the license with a new license key",
 		Long:  "Update the SUSE Observability license with a new license key. The new license takes effect immediately.",
 		Example: `# update the license

--- a/cmd/monitor/monitor_apply.go
+++ b/cmd/monitor/monitor_apply.go
@@ -18,7 +18,7 @@ type ApplyArgs struct {
 func MonitorApplyCommand(cli *di.Deps) *cobra.Command {
 	args := &ApplyArgs{}
 	cmd := &cobra.Command{
-		Use:   "apply --file FILE",
+		Use:   "apply",
 		Short: "Create or update a monitor from an STY file",
 		Long:  "Create or update a monitor from an STY (SUSE Observability YAML) file. If the monitor already exists, it will be updated.",
 		Example: `# apply a monitor definition

--- a/cmd/monitor/monitor_clone.go
+++ b/cmd/monitor/monitor_clone.go
@@ -18,7 +18,7 @@ type CloneArgs struct {
 func MonitorCloneCommand(cli *di.Deps) *cobra.Command {
 	args := &CloneArgs{}
 	cmd := &cobra.Command{
-		Use:   "clone {--id ID | --identifier URN} --name NAME",
+		Use:   "clone",
 		Short: "Clone an existing monitor to create an editable copy",
 		Long:  `Clone an existing monitor to create a new copy with a different name. This is useful for creating custom versions of locked monitors from StackPacks.`,
 		Example: `# clone a monitor by ID

--- a/cmd/monitor/monitor_delete.go
+++ b/cmd/monitor/monitor_delete.go
@@ -18,7 +18,7 @@ type DeleteArgs struct {
 func MonitorDeleteCommand(cli *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete {--id ID | --identifier URN}",
+		Use:   "delete",
 		Short: "Delete a monitor permanently",
 		Long:  "Delete a monitor by its ID or identifier. This removes the monitor and all its associated health states.",
 		Example: `# delete a monitor by ID

--- a/cmd/monitor/monitor_describe.go
+++ b/cmd/monitor/monitor_describe.go
@@ -19,7 +19,7 @@ type DescribeArgs struct {
 func MonitorDescribeCommand(cli *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe --id ID",
+		Use:   "describe",
 		Short: "Export a monitor definition in STY format",
 		Long:  "Export the monitor definition in STY (SUSE Observability YAML) format. Output can be printed to stdout or saved to a file for backup or migration.",
 		Example: `# describe a monitor to stdout

--- a/cmd/monitor/monitor_disable.go
+++ b/cmd/monitor/monitor_disable.go
@@ -13,7 +13,7 @@ import (
 func MonitorDisableCommand(cli *di.Deps) *cobra.Command {
 	args := &IdArgs{}
 	cmd := &cobra.Command{
-		Use:   "disable {--id ID | --identifier URN}",
+		Use:   "disable",
 		Short: "Disable a monitor to stop it from running",
 		Long:  "Disable a monitor to prevent it from running on its scheduled interval. A disabled monitor will not produce new health states.",
 		Example: `# disable a monitor by ID

--- a/cmd/monitor/monitor_edit.go
+++ b/cmd/monitor/monitor_edit.go
@@ -24,7 +24,7 @@ type EditArgs struct {
 func MonitorEditCommand(cli *di.Deps) *cobra.Command {
 	args := &EditArgs{}
 	cmd := &cobra.Command{
-		Use:   "edit {--id ID | --identifier URN}",
+		Use:   "edit",
 		Short: "Edit a monitor interactively in your default editor",
 		Long:  `Edit a monitor interactively. Opens the monitor definition in the editor defined by your VISUAL or EDITOR environment variable. Locked monitors (from StackPacks) require cloning first.`,
 		Example: `# edit a monitor by ID

--- a/cmd/monitor/monitor_enable.go
+++ b/cmd/monitor/monitor_enable.go
@@ -13,7 +13,7 @@ import (
 func MonitorEnableCommand(cli *di.Deps) *cobra.Command {
 	args := &IdArgs{}
 	cmd := &cobra.Command{
-		Use:   "enable {--id ID | --identifier URN}",
+		Use:   "enable",
 		Short: "Enable a disabled monitor to resume scheduled execution",
 		Long:  "Enable a disabled monitor to resume running on its configured schedule. The monitor will start producing health states again.",
 		Example: `# enable a monitor by ID

--- a/cmd/monitor/monitor_run.go
+++ b/cmd/monitor/monitor_run.go
@@ -22,7 +22,7 @@ type RunArgs struct {
 func MonitorRunCommand(cli *di.Deps) *cobra.Command {
 	args := &RunArgs{}
 	cmd := &cobra.Command{
-		Use:   "run {--id ID | --identifier URN}",
+		Use:   "run",
 		Short: "Execute a monitor and display the results",
 		Long:  `Execute a monitor and display the results. By default runs in dry-run mode without saving health states. Use --yes to persist the resulting health states.`,
 		Example: `# dry-run a monitor (no state changes)

--- a/cmd/monitor/monitor_status.go
+++ b/cmd/monitor/monitor_status.go
@@ -21,7 +21,7 @@ type StatusArgs struct {
 func MonitorStatusCommand(cli *di.Deps) *cobra.Command {
 	args := &StatusArgs{}
 	cmd := &cobra.Command{
-		Use:   "status {--id ID | --identifier URN}",
+		Use:   "status",
 		Short: "Show detailed runtime status of a monitor",
 		Long:  `Show detailed runtime status of a monitor including health state counts, stream metrics, errors, and topology matching results.`,
 		Example: `# show monitor status by ID

--- a/cmd/otelcomponentmapping/otelcomponentmapping_apply.go
+++ b/cmd/otelcomponentmapping/otelcomponentmapping_apply.go
@@ -20,7 +20,7 @@ type ApplyArgs struct {
 func OtelComponentMappingApplyCommand(deps *di.Deps) *cobra.Command {
 	args := &ApplyArgs{}
 	cmd := &cobra.Command{
-		Use:   "apply --file FILE",
+		Use:   "apply",
 		Short: "Create or edit an OTel Component Mapping from YAML",
 		Long:  "Create or edit a OTel Component Mapping from YAML file.",
 		Example: `# create a new OTel component mapping from a YAML file

--- a/cmd/otelcomponentmapping/otelcomponentmapping_delete.go
+++ b/cmd/otelcomponentmapping/otelcomponentmapping_delete.go
@@ -16,7 +16,7 @@ type DeleteArgs struct {
 func OtelComponentMappingDeleteCommand(deps *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete --identifier URN",
+		Use:   "delete",
 		Short: "Delete an OTel Component Mapping by identifier (URN)",
 		Long:  "Delete an OTel Component Mapping by identifier (URN)",
 		Example: `# delete a component mapping by identifier

--- a/cmd/otelcomponentmapping/otelcomponentmapping_describe.go
+++ b/cmd/otelcomponentmapping/otelcomponentmapping_describe.go
@@ -19,7 +19,7 @@ type DescribeArgs struct {
 func OtelComponentMappingDescribeCommand(deps *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe --identifier URN",
+		Use:   "describe",
 		Short: "Describe an Otel Component Mapping",
 		Long:  "Describe an Otel Component Mapping by identifier (URN). Optionally write to output file.",
 		Example: `# describe an OTel component mapping by identifier

--- a/cmd/otelcomponentmapping/otelcomponentmapping_edit.go
+++ b/cmd/otelcomponentmapping/otelcomponentmapping_edit.go
@@ -26,7 +26,7 @@ type EditArgs struct {
 func OtelComponentMappingEditCommand(deps *di.Deps) *cobra.Command {
 	args := &EditArgs{}
 	cmd := &cobra.Command{
-		Use:   "edit --identifier URN",
+		Use:   "edit",
 		Short: "Edit an OTel Component Mapping using $EDITOR",
 		Long:  LongDescription,
 		Example: `# edit a component mapping using your editor

--- a/cmd/otelrelationmapping/otelrelationmapping_apply.go
+++ b/cmd/otelrelationmapping/otelrelationmapping_apply.go
@@ -20,7 +20,7 @@ type ApplyArgs struct {
 func OtelRelationMappingApplyCommand(deps *di.Deps) *cobra.Command {
 	args := &ApplyArgs{}
 	cmd := &cobra.Command{
-		Use:   "apply --file FILE",
+		Use:   "apply",
 		Short: "Create or edit an OTel Relation Mapping from YAML",
 		Long:  "Create or edit an OTel Relation Mapping from YAML file.",
 		Example: `# create a new OTel relation mapping from a YAML file

--- a/cmd/otelrelationmapping/otelrelationmapping_delete.go
+++ b/cmd/otelrelationmapping/otelrelationmapping_delete.go
@@ -16,7 +16,7 @@ type DeleteArgs struct {
 func OtelRelationMappingDeleteCommand(deps *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete --identifier URN",
+		Use:   "delete",
 		Short: "Delete an OTel Relation Mapping by identifier (URN)",
 		Long:  "Delete an OTel Relation Mapping by identifier (URN).",
 		Example: `# delete a relation mapping by identifier

--- a/cmd/otelrelationmapping/otelrelationmapping_describe.go
+++ b/cmd/otelrelationmapping/otelrelationmapping_describe.go
@@ -19,7 +19,7 @@ type DescribeArgs struct {
 func OtelRelationMappingDescribeCommand(deps *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe --identifier URN",
+		Use:   "describe",
 		Short: "Describe an OTel Relation Mapping by identifier (URN)",
 		Long:  "Describe an OTel Relation Mapping by identifier (URN). Optionally write to output file.",
 		Example: `# describe an OTel relation mapping by identifier

--- a/cmd/otelrelationmapping/otelrelationmapping_edit.go
+++ b/cmd/otelrelationmapping/otelrelationmapping_edit.go
@@ -26,7 +26,7 @@ type EditArgs struct {
 func OtelRelationMappingEditCommand(deps *di.Deps) *cobra.Command {
 	args := &EditArgs{}
 	cmd := &cobra.Command{
-		Use:   "edit --identifier URN",
+		Use:   "edit",
 		Short: "Edit an OTel Relation Mapping using $EDITOR",
 		Long:  LongDescription,
 		Example: `# edit a relation mapping using your editor

--- a/cmd/rbac/rbac_create_subject.go
+++ b/cmd/rbac/rbac_create_subject.go
@@ -17,7 +17,7 @@ type CreateSubjectArgs struct {
 func CreateSubjectCommand(deps *di.Deps) *cobra.Command {
 	args := &CreateSubjectArgs{}
 	cmd := &cobra.Command{
-		Use:   "create-subject --subject SUBJECT",
+		Use:   "create-subject",
 		Short: "Create a new security subject",
 		Long:  "Create a new security subject for RBAC. Subjects can be users or groups that can be granted permissions.",
 		Example: `# create a new subject

--- a/cmd/rbac/rbac_delete_subject.go
+++ b/cmd/rbac/rbac_delete_subject.go
@@ -15,7 +15,7 @@ type DeleteSubjectArgs struct {
 func DeleteSubjectCommand(deps *di.Deps) *cobra.Command {
 	args := &DeleteSubjectArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete-subject --subject SUBJECT",
+		Use:   "delete-subject",
 		Short: "Delete a security subject",
 		Long:  "Delete a security subject and revoke all its permissions. This operation cannot be undone.",
 		Example: `# delete a subject

--- a/cmd/rbac/rbac_describe_permissions.go
+++ b/cmd/rbac/rbac_describe_permissions.go
@@ -23,7 +23,7 @@ type DescribePermissionsArgs struct {
 func DescribePermissionsCommand(deps *di.Deps) *cobra.Command {
 	args := &DescribePermissionsArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe-permissions --subject SUBJECT",
+		Use:   "describe-permissions",
 		Short: "Show permissions granted to a subject",
 		Long:  "Show all permissions granted to a subject. Can filter by permission type or resource.",
 		Example: `# show all permissions for a subject

--- a/cmd/rbac/rbac_grant.go
+++ b/cmd/rbac/rbac_grant.go
@@ -16,7 +16,7 @@ type GrantPermissionsArgs struct {
 func GrantPermissionsCommand(deps *di.Deps) *cobra.Command {
 	args := &GrantPermissionsArgs{}
 	cmd := &cobra.Command{
-		Use:   "grant --subject SUBJECT --permission PERMISSION",
+		Use:   "grant",
 		Short: "Grant a permission to a subject",
 		Long:  "Grant a permission to a subject on a resource. Use 'sts rbac list-permissions' to see available permissions.",
 		Example: `# grant access-view permission to all resources

--- a/cmd/rbac/rbac_revoke.go
+++ b/cmd/rbac/rbac_revoke.go
@@ -16,7 +16,7 @@ type RevokePermissionsArgs struct {
 func RevokePermissionsCommand(deps *di.Deps) *cobra.Command {
 	args := &RevokePermissionsArgs{}
 	cmd := &cobra.Command{
-		Use:   "revoke --subject SUBJECT --permission PERMISSION",
+		Use:   "revoke",
 		Short: "Revoke a permission from a subject",
 		Long:  "Revoke a previously granted permission from a subject on a resource.",
 		Example: `# revoke access-view permission from all resources

--- a/cmd/script/script_run.go
+++ b/cmd/script/script_run.go
@@ -27,7 +27,7 @@ const (
 func ScriptRunCommand(cli *di.Deps) *cobra.Command {
 	args := &ScriptRunArgs{}
 	cmd := &cobra.Command{
-		Use:   "run {--script SCRIPT | --file FILE}",
+		Use:   "run",
 		Short: "Execute an STSL script on the server",
 		Long:  "Execute an STSL (SUSE Observability Scripting Language) script on the server. Scripts can be provided inline or loaded from a file. Use --arguments-script to pass variables to the script.",
 		Example: `# run a script from file

--- a/cmd/servicetoken/servicetoken_create.go
+++ b/cmd/servicetoken/servicetoken_create.go
@@ -25,7 +25,7 @@ type CreateArgs struct {
 func CreateCommand(deps *di.Deps) *cobra.Command {
 	args := &CreateArgs{}
 	cmd := &cobra.Command{
-		Use:   "create --name NAME --roles ROLES",
+		Use:   "create",
 		Short: "Create a new service token",
 		Long:  "Create a new service token for API authentication. The token is shown once upon creation and cannot be retrieved later.",
 		Example: `# create a token with admin role

--- a/cmd/servicetoken/servicetoken_delete.go
+++ b/cmd/servicetoken/servicetoken_delete.go
@@ -16,7 +16,7 @@ type DeleteArgs struct {
 func DeleteCommand(deps *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete --id ID",
+		Use:   "delete",
 		Short: "Delete a service token",
 		Long:  "Delete a service token by ID. This also removes any dedicated subject associated with the token.",
 		Example: `# delete a service token

--- a/cmd/settings/settings_apply.go
+++ b/cmd/settings/settings_apply.go
@@ -29,7 +29,7 @@ type ApplyArgs struct {
 func SettingsApplyCommand(cli *di.Deps) *cobra.Command {
 	args := &ApplyArgs{}
 	cmd := &cobra.Command{
-		Use:   "apply --file FILE",
+		Use:   "apply",
 		Short: "Import settings from an STY or STJ file",
 		Long:  "Import settings from an STY (SUSE Observability YAML) or STJ (SUSE Observability JSON) file. Can import to a specific namespace with conflict resolution strategies.",
 		Example: `# apply settings from file

--- a/cmd/settings/settings_delete.go
+++ b/cmd/settings/settings_delete.go
@@ -18,7 +18,7 @@ type DeleteArgs struct {
 func SettingsDeleteCommand(cli *di.Deps) *cobra.Command {
 	args := &DeleteArgs{}
 	cmd := &cobra.Command{
-		Use:   "delete --ids IDS",
+		Use:   "delete",
 		Short: "Delete settings by ID",
 		Long:  "Delete one or more settings by their IDs. This operation cannot be undone.",
 		Example: `# delete a setting

--- a/cmd/settings/settings_describe.go
+++ b/cmd/settings/settings_describe.go
@@ -22,7 +22,7 @@ type DescribeArgs struct {
 func SettingsDescribeCommand(cli *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe {--ids IDS | --namespace NAMESPACE | --type TYPE}",
+		Use:   "describe",
 		Short: "Export settings to STY format",
 		Long:  "Export settings to STY (SUSE Observability YAML) format. Filter by IDs, namespace, or type. Output can be saved to a file for backup or migration.",
 		Example: `# export specific settings by ID

--- a/cmd/settings/settings_edit.go
+++ b/cmd/settings/settings_edit.go
@@ -34,7 +34,7 @@ type EditArgs struct {
 func SettingsEditCommand(cli *di.Deps) *cobra.Command {
 	args := &EditArgs{}
 	cmd := &cobra.Command{
-		Use:   "edit {--ids IDS | --type TYPE}",
+		Use:   "edit",
 		Short: "Edit settings interactively in an editor",
 		Long:  LongDescription,
 		Example: `# edit specific settings by ID

--- a/cmd/settings/settings_list.go
+++ b/cmd/settings/settings_list.go
@@ -21,7 +21,7 @@ type ListArgs struct {
 func SettingsListCommand(cli *di.Deps) *cobra.Command {
 	args := &ListArgs{}
 	cmd := &cobra.Command{
-		Use:   "list --type TYPE",
+		Use:   "list",
 		Short: "List all settings of a specific type",
 		Long:  "List all settings of a specific type. Use 'sts settings list-types' to see available types. Can filter by namespace or owner.",
 		Example: `# list all monitors

--- a/cmd/settings/settings_unlock.go
+++ b/cmd/settings/settings_unlock.go
@@ -19,7 +19,7 @@ type UnlockArgs struct {
 func SettingsUnlockCommand(cli *di.Deps) *cobra.Command {
 	args := &UnlockArgs{}
 	cmd := &cobra.Command{
-		Use:   "unlock --ids IDS",
+		Use:   "unlock",
 		Short: "Unlock settings locked by StackPacks",
 		Long:  `Unlock settings locked by StackPacks to allow editing. Warning: Unlocking settings may prevent StackPacks from upgrading correctly.`,
 		Example: `# unlock a setting by ID

--- a/cmd/stackpack/stackpack_confirm_manual_steps.go
+++ b/cmd/stackpack/stackpack_confirm_manual_steps.go
@@ -17,7 +17,7 @@ type ManualStepsArgs struct {
 func StackpackConfirmManualStepsCommand(cli *di.Deps) *cobra.Command {
 	args := &ManualStepsArgs{}
 	cmd := &cobra.Command{
-		Use:   "confirm-manual-steps --name NAME --id ID",
+		Use:   "confirm-manual-steps",
 		Short: "Confirm completion of manual installation steps",
 		Long:  `Confirm that manual installation steps have been completed for a StackPack instance. Some StackPacks require manual actions that cannot be verified automatically.`,
 		Example: `# confirm manual steps for a StackPack instance

--- a/cmd/stackpack/stackpack_describe.go
+++ b/cmd/stackpack/stackpack_describe.go
@@ -23,7 +23,7 @@ type DescribeArgs struct {
 func StackpackDescribeCommand(cli *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe --name NAME",
+		Use:   "describe",
 		Short: "Show detailed information about a StackPack",
 		Long:  "Show detailed information about a StackPack including version, categories, integrations, parameters, and installed instances.",
 		Example: `# describe the kubernetes StackPack

--- a/cmd/stackpack/stackpack_install.go
+++ b/cmd/stackpack/stackpack_install.go
@@ -26,7 +26,7 @@ func StackpackInstallCommand(cli *di.Deps) *cobra.Command {
 		Params: make(map[string]string),
 	}
 	cmd := &cobra.Command{
-		Use:   "install --name NAME",
+		Use:   "install",
 		Short: "Install a new instance of a StackPack",
 		Long:  `Install a new instance of a StackPack. Use 'sts stackpack list-parameters --name NAME' to see required parameters.`,
 		Example: `# install an example StackPack with parameters

--- a/cmd/stackpack/stackpack_list_instances.go
+++ b/cmd/stackpack/stackpack_list_instances.go
@@ -14,7 +14,7 @@ import (
 func StackpackListInstanceCommand(cli *di.Deps) *cobra.Command {
 	args := &ListPropertiesArgs{}
 	cmd := &cobra.Command{
-		Use:   "list-instances --name NAME",
+		Use:   "list-instances",
 		Short: "List installed instances of a StackPack",
 		Long:  "List all installed instances of a StackPack. Shows instance ID, status, version, and last update time.",
 		Example: `# list instances of the kubernetes StackPack

--- a/cmd/stackpack/stackpack_list_parameters.go
+++ b/cmd/stackpack/stackpack_list_parameters.go
@@ -14,7 +14,7 @@ import (
 func StackpackListParameterCommand(cli *di.Deps) *cobra.Command {
 	args := &ListPropertiesArgs{}
 	cmd := &cobra.Command{
-		Use:   "list-parameters --name NAME",
+		Use:   "list-parameters",
 		Short: "List installation parameters for a StackPack",
 		Long:  "List all parameters required to install a StackPack. Use these parameter names with 'sts stackpack install -p key=value'.",
 		Example: `# list parameters for the kubernetes StackPack

--- a/cmd/stackpack/stackpack_test_deploy_cmd_test.go
+++ b/cmd/stackpack/stackpack_test_deploy_cmd_test.go
@@ -212,7 +212,10 @@ func TestStackpackTestDeployCommand_DirectoryHandling(t *testing.T) {
 	require.NoError(t, os.MkdirAll(stackpackDir, 0755))
 
 	// Create required files
-	createTestStackpack(t, stackpackDir, "test-stackpack", "1.0.0")
+	stackpackName := "test-stackpack"
+	stackPackCurrentVersion := "1.0.0"
+	createTestStackpack(t, stackpackDir, stackpackName, stackPackCurrentVersion)
+	stackpackTestArchive := fmt.Sprintf("%s-%s-cli-test.10000.sts", stackpackName, stackPackCurrentVersion)
 
 	cli, cmd := setupStackpackTestDeployCmd(t)
 
@@ -231,6 +234,7 @@ func TestStackpackTestDeployCommand_DirectoryHandling(t *testing.T) {
 			// Note: This test will fail at the API call stage since we're using mock deps
 			// But we can verify that directory parsing works
 			_, err := di.ExecuteCommandWithContext(&cli.Deps, cmd, tt.args...)
+			defer os.Remove(stackpackTestArchive)
 
 			// Should fail on API calls (upload/install), not on directory or config parsing
 			if err != nil {

--- a/cmd/stackpack/stackpack_uninstall.go
+++ b/cmd/stackpack/stackpack_uninstall.go
@@ -17,7 +17,7 @@ type UninstallArgs struct {
 func StackpackUninstallCommand(cli *di.Deps) *cobra.Command {
 	args := &UninstallArgs{}
 	cmd := &cobra.Command{
-		Use:   "uninstall --name NAME --id ID",
+		Use:   "uninstall",
 		Short: "Uninstall a StackPack instance",
 		Long:  "Uninstall a StackPack instance by name and ID. Use 'sts stackpack list-instances' to find instance IDs.",
 		Example: `# uninstall a StackPack instance

--- a/cmd/stackpack/stackpack_upgrade.go
+++ b/cmd/stackpack/stackpack_upgrade.go
@@ -28,7 +28,7 @@ type UpgradeArgs struct {
 func StackpackUpgradeCommand(cli *di.Deps) *cobra.Command {
 	args := &UpgradeArgs{}
 	cmd := &cobra.Command{
-		Use:   "upgrade --name NAME",
+		Use:   "upgrade",
 		Short: "Upgrade a StackPack to the next version",
 		Long:  "Upgrade all instances of a StackPack to the next available version. Check 'sts stackpack list' to see available upgrades.",
 		Example: `# upgrade a StackPack

--- a/cmd/stackpack/stackpack_upload.go
+++ b/cmd/stackpack/stackpack_upload.go
@@ -18,7 +18,7 @@ type UploadArgs struct {
 func StackpackUploadCommand(cli *di.Deps) *cobra.Command {
 	args := &UploadArgs{}
 	cmd := &cobra.Command{
-		Use:   "upload --file FILE",
+		Use:   "upload",
 		Short: "Upload a StackPack file to the server",
 		Long:  "Upload a StackPack file (.sts) to SUSE Observability. After upload, the StackPack can be installed using 'sts stackpack install'.",
 		Example: `# upload a StackPack

--- a/cmd/style_rules_test.go
+++ b/cmd/style_rules_test.go
@@ -12,12 +12,8 @@ import (
 )
 
 var (
-	startWithLowerCaseWordExceptions = `StackState`                                                                      //nolint:unused,varcheck
-	startWithLowerCaseWord           = regexp.MustCompile(`^([a-z][a-z0-9-]*|` + startWithLowerCaseWordExceptions + `)`) //nolint:unused,varcheck
-	startWithUpperCaseWord           = regexp.MustCompile(`^[A-Z0-9]`)
-	endsWithFullStop                 = regexp.MustCompile(`\s*\.\s*$`)
-	startsLowerCaseExceptions        = `\.sty`                                                          //nolint:unused,varcheck
-	startsLowerCase                  = regexp.MustCompile(`^([a-z]|` + startsLowerCaseExceptions + `)`) //nolint:unused,varcheck
+	startWithUpperCaseWord = regexp.MustCompile(`^[A-Z0-9]`)
+	endsWithFullStop       = regexp.MustCompile(`\s*\.\s*$`)
 )
 
 func setupCmd(t *testing.T) *cobra.Command {
@@ -25,7 +21,7 @@ func setupCmd(t *testing.T) *cobra.Command {
 	return STSCommand(&cli.Deps)
 }
 
-//--- cmd.Use ---
+// --- cmd.Use ---
 
 func TestEachNounCommandHasVerbsAndEachVerbHasNoChildren(t *testing.T) {
 	root := setupCmd(t)
@@ -44,17 +40,16 @@ func TestEachNounCommandHasVerbsAndEachVerbHasNoChildren(t *testing.T) {
 	}
 }
 
-func TestUseStartsWithLowerCaseWord(t *testing.T) {
+func TestUseShouldOnlyContainCommandName(t *testing.T) {
 	root := setupCmd(t)
-	r := regexp.MustCompile(`^[a-z][a-z0-9-]*`)
 	stscobra.ForAllCmd(root, func(cmd *cobra.Command) {
-		if !r.MatchString(cmd.Use) {
-			assert.Fail(t, cmd.Use+" does not match "+r.String())
+		if cmd.Use != cmd.Name() {
+			assert.Fail(t, cmd.CommandPath()+" Use field should only contain the command name: "+cmd.Use)
 		}
 	})
 }
 
-//--- cmd.Short ---
+// --- cmd.Short ---
 
 func TestShortShouldExist(t *testing.T) {
 	root := setupCmd(t)
@@ -83,7 +78,7 @@ func TestShortShouldNotEndWithFullStop(t *testing.T) {
 	})
 }
 
-//--- cmd.Long ---
+// --- cmd.Long ---
 
 func TestLongShouldExist(t *testing.T) {
 	root := setupCmd(t)
@@ -112,7 +107,7 @@ func TestLongShouldEndWithAFullStop(t *testing.T) {
 	})
 }
 
-//--- flag.Usage ---
+// --- flag.Usage ---
 
 func TestFlagUsageShouldNotEndWithFullStop(t *testing.T) {
 	root := setupCmd(t)
@@ -132,7 +127,7 @@ func TestFlagUsageShouldStartWithUpperCase(t *testing.T) {
 	})
 }
 
-//--- flag.Shorthand ---
+// --- flag.Shorthand ---
 
 func TestFlagShortHandMustBeConsistentAmongstCommands(t *testing.T) {
 	root := setupCmd(t)

--- a/cmd/topic/topic_describe.go
+++ b/cmd/topic/topic_describe.go
@@ -39,7 +39,7 @@ type DescribeArgs struct {
 func DescribeCommand(deps *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe --name NAME",
+		Use:   "describe",
 		Short: "Read messages from a Kafka topic",
 		Long:  "Read messages from a Kafka topic. Can filter by partition and offset, and save output to a file.",
 		Example: `# read latest 10 messages from a topic

--- a/cmd/topologysync/topologysync_clear_errors.go
+++ b/cmd/topologysync/topologysync_clear_errors.go
@@ -16,7 +16,7 @@ type ClearErrorsArgs struct {
 func ClearErrorsCommand(deps *di.Deps) *cobra.Command {
 	args := &ClearErrorsArgs{}
 	cmd := &cobra.Command{
-		Use:   "clear-errors {--id ID | --identifier URN}",
+		Use:   "clear-errors",
 		Short: "Clear errors from a topology synchronization",
 		Long:  "Clear all errors from a topology synchronization. Use this after resolving the underlying data issues.",
 		Example: `# clear errors by ID

--- a/cmd/topologysync/topologysync_describe.go
+++ b/cmd/topologysync/topologysync_describe.go
@@ -24,7 +24,7 @@ type DescribeArgs struct {
 func DescribeCommand(deps *di.Deps) *cobra.Command {
 	args := &DescribeArgs{}
 	cmd := &cobra.Command{
-		Use:   "describe {--id ID | --identifier URN}",
+		Use:   "describe",
 		Short: "Show detailed status of a topology synchronization",
 		Long:  "Show detailed status of a topology synchronization including metrics, latency, and error details.",
 		Example: `# describe a synchronization by ID


### PR DESCRIPTION
- This mr removes repetitions for the command flags in "Usage" descriptions of the CLI commands. Basically, this field is built by the cli itself and render the final Usage accordingly.
- A test was added to ensure cmd.Use == cmd.Name.
- A small adjustment to a test function to remove a temporary file.