### PR TITLE
STAC-0: rename stackpack delete version flag to stackpack-version

### DIFF
--- a/cmd/stackpack/flags.go
+++ b/cmd/stackpack/flags.go
@@ -6,7 +6,7 @@ const (
 	IdFlag               = "id"
 	NameFlag             = "name"
 	UnlockedStrategyFlag = "unlocked-strategy"
-	VersionFlag          = "version"
+	StackpackVersionFlag = "stackpack-version"
 	AllFlag              = "all"
 	DevOnlyFlag          = "dev-only"
 )

--- a/cmd/stackpack/stackpack_delete_version.go
+++ b/cmd/stackpack/stackpack_delete_version.go
@@ -21,12 +21,12 @@ func StackpackDeleteVersionCommand(cli *di.Deps) *cobra.Command {
 		Short: "Delete a specific version of a StackPack",
 		Long:  "Delete a specific version of a StackPack from the server. The version cannot be deleted if it is currently in use by an installed instance.",
 		Example: `# delete version 1.0.0 of the kubernetes StackPack
-sts stackpack delete-version --name kubernetes --version 1.0.0`,
+sts stackpack delete-version --name kubernetes --stackpack-version 1.0.0`,
 		RunE: cli.CmdRunEWithApi(RunStackpackDeleteVersionCommand(args)),
 	}
 	common.AddRequiredNameFlagVar(cmd, &args.Name, "Name of the StackPack")
-	cmd.Flags().StringVar(&args.Version, VersionFlag, "", "Version to delete")
-	cmd.MarkFlagRequired(VersionFlag) //nolint:errcheck
+	cmd.Flags().StringVar(&args.Version, StackpackVersionFlag, "", "Version to delete")
+	cmd.MarkFlagRequired(StackpackVersionFlag) //nolint:errcheck
 	return cmd
 }
 

--- a/cmd/stackpack/stackpack_delete_version_test.go
+++ b/cmd/stackpack/stackpack_delete_version_test.go
@@ -16,7 +16,7 @@ func setupStackPackDeleteVersionCmd(t *testing.T) (*di.MockDeps, *cobra.Command)
 
 func TestStackpackDeleteVersionPrintToConsole(t *testing.T) {
 	cli, cmd := setupStackPackDeleteVersionCmd(t)
-	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "delete-version", "--name", "kubernetes", "--version", "1.0.0")
+	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "delete-version", "--name", "kubernetes", "--stackpack-version", "1.0.0")
 
 	expectedSuccessMessage := []string{"Successfully deleted version 1.0.0 of StackPack kubernetes"}
 	assert.True(t, cli.MockPrinter.HasNonJsonCalls)
@@ -30,7 +30,7 @@ func TestStackpackDeleteVersionPrintToConsole(t *testing.T) {
 
 func TestStackpackDeleteVersionPrintToJson(t *testing.T) {
 	cli, cmd := setupStackPackDeleteVersionCmd(t)
-	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "delete-version", "--name", "kubernetes", "--version", "1.0.0", "-o", "json")
+	di.ExecuteCommandWithContextUnsafe(&cli.Deps, cmd, "delete-version", "--name", "kubernetes", "--stackpack-version", "1.0.0", "-o", "json")
 
 	expectedJsonCalls := []map[string]interface{}{{
 		"deleted": "1.0.0",


### PR DESCRIPTION
`sts stackpack delete --name open-telemetry-2 --version some-version` resulted in:
```sh
"version" flag declared as non-bool. Please correct your code
```
The string based `version` flag was overshadowing the persistent bool `version` flag for Cobra, breaking its lookup. 