### PR TITLE
STAC-0: consolidate stackpack 2.0 feature flags

### DIFF
--- a/cmd/stackpack.go
+++ b/cmd/stackpack.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	experimentalStackpackEnvVar = "STS_EXPERIMENTAL_STACKPACK"
+	experimentalStackpackEnvVar = "STS_EXPERIMENTAL_STACKPACKS"
 )
 
 func StackPackCommand(cli *di.Deps) *cobra.Command {

--- a/cmd/stackpack/stackpack_validate.go
+++ b/cmd/stackpack/stackpack_validate.go
@@ -35,7 +35,7 @@ This command validates a stackpack by uploading it to the server.
 
 Exactly one of --stackpack-directory or --stackpack-file must be specified.
 
-This command is experimental and requires STS_EXPERIMENTAL_STACKPACK environment variable to be set.`,
+This command is experimental and requires STS_EXPERIMENTAL_STACKPACKS environment variable to be set.`,
 		Example: `# Validate a stackpack directory (automatically packaged)
 sts stackpack validate --stackpack-directory ./my-stackpack
 

--- a/cmd/sts.go
+++ b/cmd/sts.go
@@ -36,7 +36,7 @@ func STSCommand(cli *di.Deps) *cobra.Command {
 	cmd.AddCommand(TopologyCommand(cli))
 
 	// Experimental commands for otel mapping
-	if os.Getenv("STS_EXPERIMENTAL_OTEL_MAPPING") != "" {
+	if os.Getenv("STS_EXPERIMENTAL_STACKPACKS") != "" {
 		cmd.AddCommand(OtelComponentMappingCommand(cli))
 		cmd.AddCommand(OtelRelationMappingCommand(cli))
 	}


### PR DESCRIPTION
Merge `STS_EXPERIMENTAL_STACKPACK` and `STS_EXPERIMENTAL_OTEL_MAPPING` into `STS_EXPERIMENTAL_STACKPACKS` - the same form/convention as the helm chart global feature flag name: `experimentalStackpacks`