### PR TITLE
Pin CLI releases to Go 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
       - name: License scanning
         run: |
           go install github.com/google/go-licenses@latest
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
       - name: Run tests
         run: go test -v ./...
 
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         if: github.event_name != 'pull_request'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackvista/stackstate-cli
 
-go 1.25.0
+go 1.25.13
 
 replace github.com/spf13/pflag => github.com/stackvista/pflag v1.22.0
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.2"
+go = "1.26.6"
 golangci-lint = "2.11.3"
 pre-commit = "4.5.1"
 yq = "4.52.4"


### PR DESCRIPTION
Pin the release build to fixed Go 1.25.13 through `go.mod`, make every setup-go job consume that file, and update the local development toolchain. A new CLI tag after merge will replace vulnerable v3.3.7.

Tracking: https://github.com/StackVista/cve-reporter/issues/32

Validation: `go test ./...`; release-style binary built with `GOTOOLCHAIN=go1.25.13` reports `go1.25.13`.